### PR TITLE
Dockerfile: do not install recommended dependencies for unoconv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,14 @@ FROM node:13
 MAINTAINER fh-reutlingen
 
 #INSTALL DEPS for doc/pdf convertion
-RUN apt-get update && apt-get install -y unoconv nano
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  unoconv \
+  libreoffice-writer \
+  libreoffice-draw \
+  libreoffice-calc \
+  libreoffice-impress \
+  nano
 
 #INSTALL Deps for puppeteer
 RUN apt-get install -y wget gnupg \


### PR DESCRIPTION
It installs most of the libreoffice and its recommended dependencies.
Instead, install libreoffice manually.

This should make image size smaller, but I don't have numbers for comparison. My image (with this change) is 2.51 GB in size. I have tested, ODP presentations convert to PDF successfully and can be presented.