### PR TITLE
Dockerfile: create /node_modules before chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN npm i puppeteer \
     && groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
     && mkdir -p /home/pptruser/Downloads \
     && chown -R pptruser:pptruser /home/pptruser \
+    && mkdir -p /node_modules \
     && chown -R pptruser:pptruser /node_modules
 
 # Bundle app source


### PR DESCRIPTION
Otherwise chown and the whole RUN fails