### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,31 @@
-FROM node:13
+FROM node:13-slim
 
-MAINTAINER fh-reutlingen
-
-#INSTALL DEPS for doc/pdf convertion
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-  unoconv \
-  libreoffice-writer \
-  libreoffice-draw \
-  libreoffice-calc \
-  libreoffice-impress
+&& apt-get install -y --no-install-recommends \
+# Install unoconv and LibreOffice for document to PDF conversion
+unoconv \
+libreoffice-writer \
+libreoffice-draw \
+libreoffice-calc \
+libreoffice-impress \
+# Install Chromium for puppeteer
+chromium \
+&& rm -rf /var/lib/apt/lists/*
 
-#INSTALL Deps for puppeteer
-RUN apt-get install -y wget gnupg \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
-      --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+# Use Debian Chromium package instead of bundled Chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV PUPPETEER_EXECUTABLE_PATH /usr/bin/chromium
 
-# Create app directory
-RUN mkdir -p /opt/app
-WORKDIR /opt/app
+WORKDIR /app
+COPY package*.json .
+RUN npm install \
+&& groupadd -r accelerator && useradd -r -g accelerator -G audio,video accelerator \
+&& mkdir -p /home/accelerator/Downloads \
+&& chown -R accelerator:accelerator /home/accelerator \
+&& chown -R accelerator:accelerator /app
 
-# Install app dependencies
-COPY ./package.json /opt/app
-RUN npm install
-
-RUN npm i puppeteer \
-    # Add user so we don't need --no-sandbox.
-    # same layer as npm install to keep re-chowned files from using up several hundred MBs more space
-    && groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
-    && mkdir -p /home/pptruser/Downloads \
-    && chown -R pptruser:pptruser /home/pptruser \
-    && mkdir -p /node_modules \
-    && chown -R pptruser:pptruser /node_modules
-
-# Bundle app source
-COPY . /opt/app
+USER accelerator
+COPY . .
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "node", "server.js" ]

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ On the first start a new folder "/config" will be generated. Take a look at "/co
 
 - [ ] Better error feedback
 - [ ] More, better docs
-- [ ] Better Etherpad configuration
-- [ ] Recording of Audio/Video (Prototyp working)
-- [ ] Convert WebRTC Streams to RTMP so we can stream to youtube/twitch live (Prototyp working)
+- [ ] SIP Integration
+- [ ] Recording of Audio/Video (Prototype working)
+- [ ] Convert WebRTC Streams to RTMP so we can stream to youtube/twitch live (Prototype working)
 
 ### GoodToKnow ###
 


### PR DESCRIPTION
 - Image size is reduced to 938 MB.
 - Base image is changed to -slim variant.
 - Closed-source Chrome is removed.
 - System Chromium by puppeteer instead of bundled version
 - Node is started directly without NPM
 - The server is started as "accelerator" user, not root